### PR TITLE
Create Media section and detail refresh media Url on Chat History

### DIFF
--- a/source/includes/en/extensions/chat-history.md
+++ b/source/includes/en/extensions/chat-history.md
@@ -11,7 +11,7 @@ To get client's **threads** or **messages** exchanged with a bot, send a command
 | uri    | **/threads**                             |
 | to     | **postmaster@msging.net** (not required) |
 
-<aside class="notice">Note: With the media expiration, to retrieve MediaLink messages with valid url, use the <b>'refreshExpiredMedia=true'</b> querystring.
+<aside class="notice">Note: With the media expiration, to retrieve MediaLink messages with a valid url, use the <b>'refreshExpiredMedia=true'</b> querystring.
 </aside>
 
 <!-- ### Get average response time

--- a/source/includes/en/extensions/chat-history.md
+++ b/source/includes/en/extensions/chat-history.md
@@ -11,7 +11,7 @@ To get client's **threads** or **messages** exchanged with a bot, send a command
 | uri    | **/threads**                             |
 | to     | **postmaster@msging.net** (not required) |
 
-<aside class="notice">Note: With the media expiration, to retrieve MediaLink messages with a valid url, use the <b>'refreshExpiredMedia=true'</b> querystring.
+<aside class="notice">Note: To have the server automatically refresh any expired `MediaLink` messages returned by `/threads` and retrieve a valid URL, pass the <b>refreshExpiredMedia=true</b> parameter into the query string.
 </aside>
 
 <!-- ### Get average response time
@@ -139,7 +139,7 @@ The following uri filters are available to get chatbot's threads:
 | $take               | Limit of total of items to be returned. The maximum value allowed is 100 |
 | $skip               | The number of elements to be skipped                                     |
 | messageDate         | Initial date on the threads query                                        |
-| refreshExpiredMedia | Defines if the expired media should be updated                           |
+| refreshExpiredMedia | Defines if the expired media links should be refreshed                   |
 
 <aside class="notice">
 Note: To recover all data, use the following uri iteratively <b>'/threads?messageId={lastMessageId}&$take=100'</b> always updating messageId with the value of the last message id obtained.
@@ -259,7 +259,7 @@ The following uri filters are available to get a chatbot's thread:
 | messageId           | Initial message id for the thread messages query        |
 | storageDate         | The reference date to search. Example: `2020-01-08T15:59:07.086Z` |
 | direction           | Possible values: `asc` and `desc`. Define whether messages will be returned after(in ascending order) or before(in descending order) a date, respectively. *Needs **storageDate** or **messageId** to be defined* |
-| refreshExpiredMedia | Defines if the expired media should be updated |
+| refreshExpiredMedia | Defines if the expired media links should be refreshed |
 
 <aside class="notice">
 Note: Both <b>storageDate</b> filter and <b>date</b> response parameter uses <b>ISO 8601</b> format. However, the return information is always at <b>GMT 00:00</b>.

--- a/source/includes/en/extensions/chat-history.md
+++ b/source/includes/en/extensions/chat-history.md
@@ -11,6 +11,8 @@ To get client's **threads** or **messages** exchanged with a bot, send a command
 | uri    | **/threads**   |
 | to     | **postmaster@msging.net** (not required) |
 
+<aside class="notice">Note: With the media expiration, to retrieve MediaLink messages with valid url, use the <b>'refreshExpiredMedia=true'</b> querystring.
+</aside>
 
 <!-- ### Get average response time
 
@@ -137,6 +139,7 @@ The following uri filters are available to get chatbot's threads:
 | $take        | Limit of total of items to be returned. The maximum value allowed is 100 |
 | $skip | The number of elements to be skipped                           |
 | messageDate  | Initial date on the threads query         |
+| refreshExpiredMedia | Defines if the expired media should be updated |
 
 
 <aside class="notice">
@@ -257,6 +260,7 @@ The following uri filters are available to get a chatbot's thread:
 | messageId  | Initial message id for the thread messages query        |
 | storageDate  | The reference date to search. Example: `2020-01-08T15:59:07.086Z` |
 | direction  | Possible values: `asc` and `desc`. Define whether messages will be returned after(in ascending order) or before(in descending order) a date, respectively. *Needs **storageDate** or **messageId** to be defined* |
+| refreshExpiredMedia | Defines if the expired media should be updated |
 
 <aside class="notice">
 Note: Both <b>storageDate</b> filter and <b>date</b> response parameter uses <b>ISO 8601</b> format. However, the return information is always at <b>GMT 00:00</b>.

--- a/source/includes/en/extensions/chat-history.md
+++ b/source/includes/en/extensions/chat-history.md
@@ -4,11 +4,11 @@ The **threads** (or **chat history**) extension allows the chatbot to retrieve t
 
 To get client's **threads** or **messages** exchanged with a bot, send a command with the following properties:
 
-| Name | Description |
-|---------------------------------|--------------|
-| id    | Unique identifier of the command.   |
-| method    | **get**  |
-| uri    | **/threads**   |
+| Name   | Description                              |
+|--------|------------------------------------------|
+| id     | Unique identifier of the command.        |
+| method | **get**                                  |
+| uri    | **/threads**                             |
 | to     | **postmaster@msging.net** (not required) |
 
 <aside class="notice">Note: With the media expiration, to retrieve MediaLink messages with valid url, use the <b>'refreshExpiredMedia=true'</b> querystring.
@@ -134,13 +134,12 @@ Getting the last chatbot's [threads](/#thread). By default, BLiP returns the las
 
 The following uri filters are available to get chatbot's threads:
 
-| QueryString  | Description                               |
-|--------------|-------------------------------------------|
-| $take        | Limit of total of items to be returned. The maximum value allowed is 100 |
-| $skip | The number of elements to be skipped                           |
-| messageDate  | Initial date on the threads query         |
-| refreshExpiredMedia | Defines if the expired media should be updated |
-
+| QueryString         | Description                                                              |
+|---------------------|--------------------------------------------------------------------------|
+| $take               | Limit of total of items to be returned. The maximum value allowed is 100 |
+| $skip               | The number of elements to be skipped                                     |
+| messageDate         | Initial date on the threads query                                        |
+| refreshExpiredMedia | Defines if the expired media should be updated                           |
 
 <aside class="notice">
 Note: To recover all data, use the following uri iteratively <b>'/threads?messageId={lastMessageId}&$take=100'</b> always updating messageId with the value of the last message id obtained.
@@ -253,13 +252,13 @@ Getting the last chatbot's [messages](/#messages) in a specific [thread](/#threa
 
 The following uri filters are available to get a chatbot's thread:
 
-| QueryString  | Description                               |
-|--------------|-------------------------------------------|
-| $skip | The number of elements to be skipped                           |
-| $take        | Limit of total of items to be returned. The maximum value allowed is 100 |
-| messageId  | Initial message id for the thread messages query        |
-| storageDate  | The reference date to search. Example: `2020-01-08T15:59:07.086Z` |
-| direction  | Possible values: `asc` and `desc`. Define whether messages will be returned after(in ascending order) or before(in descending order) a date, respectively. *Needs **storageDate** or **messageId** to be defined* |
+| QueryString         | Description                               |
+|---------------------|-------------------------------------------|
+| $skip               | The number of elements to be skipped                           |
+| $take               | Limit of total of items to be returned. The maximum value allowed is 100 |
+| messageId           | Initial message id for the thread messages query        |
+| storageDate         | The reference date to search. Example: `2020-01-08T15:59:07.086Z` |
+| direction           | Possible values: `asc` and `desc`. Define whether messages will be returned after(in ascending order) or before(in descending order) a date, respectively. *Needs **storageDate** or **messageId** to be defined* |
 | refreshExpiredMedia | Defines if the expired media should be updated |
 
 <aside class="notice">
@@ -271,9 +270,9 @@ Note: Both <b>storageDate</b> filter and <b>date</b> response parameter uses <b>
 Get all logged [messages](/#messages). By default, BLiP returns the last 100 logged messages.
 
 
-| QueryString  | Description                               |
-|--------------|-------------------------------------------|
-| $skip | The number of elements to be skipped                           |
+| QueryString  | Description                                                              |
+|--------------|--------------------------------------------------------------------------|
+| $skip        | The number of elements to be skipped                                     |
 | $take        | Limit of total of items to be returned. The maximum value allowed is 100 |
 
 ```http

--- a/source/includes/en/extensions/media.md
+++ b/source/includes/en/extensions/media.md
@@ -6,9 +6,9 @@
 
 The **Media** extension allows to manipulate the chatbot's medias.
 
-### Refresh an expired media
+### Refresh a media expired link
 
- Medias are stored with an expiration date. After this date, the media becomes unavailable. But it's possible to retrieve a new and valid url to see the media.
+ Medias are stored and accessed with expirable links. After the expiration, the media link becomes unavailable. But it's possible to retrieve a new and valid url to see the media.
 
  Name      | Description                       |
 |----------|-----------------------------------|

--- a/source/includes/en/extensions/media.md
+++ b/source/includes/en/extensions/media.md
@@ -28,7 +28,7 @@ Authorization: Key {YOUR_TOKEN}
   "id": "a43aa4d2-566a-4be0-bc51-38d43597eb58",
   "to": "postmaster@media.msging.net",
   "method": "set",
-  "uri": "/refresh/media/uri",
+  "uri": "/refresh-media-uri",
   "type": "text/plain",
   "resource": "URI_WITH_EXPIRED_TOKEN"
 }

--- a/source/includes/en/extensions/media.md
+++ b/source/includes/en/extensions/media.md
@@ -8,7 +8,7 @@ The **Media** extension allows to manipulate the chatbot's medias.
 
 ### Refresh a media expired link
 
- Medias are stored and accessed with expirable links. After the expiration, the media link becomes unavailable. This resource allows retrieving a new and valid url to see the media.
+ Medias are stored and accessed with expirable links. After the expiration date, the media link becomes unavailable. This resource allows retrieving a new and valid url to see the media.
 
  Name      | Description                       |
 |----------|-----------------------------------|

--- a/source/includes/en/extensions/media.md
+++ b/source/includes/en/extensions/media.md
@@ -8,7 +8,7 @@ The **Media** extension allows to manipulate the chatbot's medias.
 
 ### Refresh a media expired link
 
- Medias are stored and accessed with expirable links. After the expiration, the media link becomes unavailable. But it's possible to retrieve a new and valid url to see the media.
+ Medias are stored and accessed with expirable links. After the expiration, the media link becomes unavailable. This resource allows retrieving a new and valid url to see the media.
 
  Name      | Description                       |
 |----------|-----------------------------------|

--- a/source/includes/en/extensions/media.md
+++ b/source/includes/en/extensions/media.md
@@ -4,11 +4,11 @@
 |---------------------------------|
 | postmaster@media.msging.net     |
 
-The **Media** extension allows to manipulate the medias from your chatbot.
+The **Media** extension allows to manipulate the chatbot's medias.
 
 ### Refresh an expired media
 
- The medias are stored with an expiration period date. After the period, the media become unavailable. But it's possible to retrieve a new and valid url to see the media.
+ Medias are stored with an expiration date. After this date, the media becomes unavailable. But it's possible to retrieve a new and valid url to see the media.
 
  Name      | Description                       |
 |----------|-----------------------------------|

--- a/source/includes/en/extensions/media.md
+++ b/source/includes/en/extensions/media.md
@@ -1,0 +1,50 @@
+## Media
+
+| Address                         |
+|---------------------------------|
+| postmaster@media.msging.net     |
+
+The **Media** extension allows to manipulate the medias from your chatbot.
+
+### Refresh an expired media
+
+ The medias are stored with an expiration period date. After the period, the media become unavailable. But it's possible to retrieve a new and valid url to see the media.
+
+ Name      | Description                       |
+|----------|-----------------------------------|
+| id       | Unique identifier of the command. |
+| method   | `set`                             |
+| resource | The expired MediaLink Uri         |
+| uri      | **/refresh-media-uri**            |
+| to       | **postmaster@media.msging.net**   |
+| type     | `text/plain`                      |
+
+ ```http
+POST https://http.msging.net/commands HTTP/1.1
+Content-Type: application/json
+Authorization: Key {YOUR_TOKEN}
+
+{  
+  "id": "a43aa4d2-566a-4be0-bc51-38d43597eb58",
+  "to": "postmaster@media.msging.net",
+  "method": "set",
+  "uri": "/refresh/media/uri",
+  "type": "text/plain",
+  "resource": "URI_WITH_EXPIRED_TOKEN"
+}
+```
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "type": "text/plain",
+    "resource": "URI_WITH_NEW_TOKEN",
+    "method": "set",
+    "status": "success",
+    "id": "a43aa4d2-566a-4be0-bc51-38d43597eb58",
+    "from": "postmaster@media.msging.net/#az-iris1",
+    "to": "demobot@msging.net"
+}
+```

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -151,6 +151,7 @@ includes:
   - en/extensions/chatbot-profile
   - en/extensions/contacts
   - en/extensions/desk
+  - en/extensions/media
   - en/extensions/portal
   - en/extensions/resources
   - en/extensions/scheduler


### PR DESCRIPTION
In this Pull Request, I'm creating the media section to show how the users can refresh the expired media links (Because the new media rules requires these medias expires after a date).

- Crete the refresh media url section
- Change the chat history tables to show the new parameter and added a note to alert users how they can retrieve valid urls on /threads command.