### PR TITLE
Explicit the need for the Key for Resources and Buckets to be URI Encoded

### DIFF
--- a/source/includes/en/extensions/bucket.md
+++ b/source/includes/en/extensions/bucket.md
@@ -2,7 +2,8 @@
 
 The **bucket** extension allows the storage of documents in the server on an isolated chatbot's container. This extension is useful to store information about clients that have interacted with the chatbot, like preferences and navigation state.
 
-Each document has an **identifier** which is provided during the write operation and this identifier should be used for retrieving the value later. It is possible to set an optional **expiration date** for the document. Both the identifier and the expiration date are specified in the **URI** of the command which is sent to the extension.
+Each document has an **identifier** which is provided during the write operation and this identifier should be used for retrieving the value later. This **identifier** should be URI encoded.
+It is possible to set an optional **expiration date** for the document. Both the identifier and the expiration date are specified in the **URI** of the command which is sent to the extension.
 
 **Note: If expiration date is not provided, the document will never expire.**
 
@@ -22,7 +23,7 @@ The document to be stored must be passed on the `resource` property.
 
 ### Delete a Document
 
-Delete a specific document command. Remember to replace `{documentKey}` variable for the document Key that you want delete.
+Delete a specific document identified by the `abcdé 1234` key.
 
 ```http
 POST https://http.msging.net/commands HTTP/1.1
@@ -33,7 +34,7 @@ Authorization: Key {YOUR_TOKEN}
   "id": "{{$guid}}",
   "to": "postmaster@msging.net",
   "method": "delete",
-  "uri": "/buckets/{documentKey}"
+  "uri": "/buckets/abcd%c3%a9%201234"
 }
 ```
 
@@ -55,7 +56,7 @@ result = await client.process_command_async(
             'id': '{{$guid}}',
             'to': 'postmaster@msging.net',
             'method': 'delete',
-            'uri': '/buckets/{documentKey}'
+            'uri': '/buckets/abcd%c3%a9%201234'
         }
     )
 )
@@ -66,7 +67,7 @@ client.addMessageReceiver('text/plain', async (message) => {
     await client.sendCommand({  
         id: Lime.Guid(),
         method: Lime.CommandMethod.DELETE,
-        uri: '/buckets/xyz1234'
+        uri: '/buckets/abcd%c3%a9%201234'
     });
 });
 ```
@@ -78,7 +79,7 @@ client.addMessageReceiver('text/plain', async (message) => {
     await client.sendCommand({  
         id: Lime.Guid(),
         method: Lime.CommandMethod.GET,
-        uri: '/buckets/xyz1234'
+        uri: '/buckets/abcd%c3%a9%201234'
     });
 });
 ```
@@ -89,7 +90,7 @@ result = await client.process_command_async(
         {  
             'id': '{{$guid}}',
             'method': 'get',
-            'uri': '/buckets/xyz1234'
+            'uri': '/buckets/abcd%c3%a9%201234'
         }
     )
 )
@@ -103,7 +104,7 @@ Authorization: Key {YOUR_TOKEN}
 {  
   "id": "{{$guid}}",
   "method": "get",
-  "uri": "/buckets/xyz1234"
+  "uri": "/buckets/abcd%c3%a9%201234"
 }
 ```
 
@@ -149,13 +150,13 @@ namespace Extensions
 
         public async Task ReceiveAsync(Message message, CancellationToken cancellationToken)
         {
-            var document = await _bucketExtension.GetAsync<JsonDocument>("xyz1234", cancellationToken);
+            var document = await _bucketExtension.GetAsync<JsonDocument>("abcd%c3%a9%201234", cancellationToken);
         }
     }
 }
 ```
 
-Retrieving a JSON document identified by `xyz1234` key.
+Retrieving a JSON document identified by `abcdé 1234` key.
 
 ### Get a document collection
 
@@ -185,7 +186,7 @@ Content-Type: application/json
         "itemType": "text/plain",
         "items": [
             "abcd9876",
-            "xyz1234"
+            "abcdé 1234"
         ]
     },
     "method": "get",
@@ -365,7 +366,7 @@ client.addMessageReceiver('text/plain', async (message) => {
     await client.sendCommand({
         id: Lime.Guid(),
         method: Lime.CommandMethod.SET,
-        uri: '/buckets/xyz1234',
+        uri: '/buckets/abcd%c3%a9%201234',
         type: 'application/json',
         resource: {  
             'key1': 'value1',
@@ -385,7 +386,7 @@ async def message_receiver_async(message: Message) -> None:
             {  
                 'id': '{{$guid}}',
                 'method': 'set',
-                'uri': '/buckets/xyz1234',
+                'uri': '/buckets/abcd%c3%a9%201234',
                 'type': 'application/json',
                 'resource': {  
                     'key1': 'value1',
@@ -409,7 +410,7 @@ Authorization: Key {YOUR_TOKEN}
 {  
   "id": "{{$guid}}",
   "method": "set",
-  "uri": "/buckets/xyz1234",
+  "uri": "/buckets/abcd%c3%a9%201234",
   "type": "application/json",
   "resource": {  
     "key1": "value1",
@@ -461,10 +462,10 @@ namespace Extensions
             jsonDocument.Add("key2", 2);
             jsonDocument.Add("key3", new string[] { "3a", "3b", "3c"} );
 
-            await _bucketExtension.SetAsync("xyz1234", jsonDocument);
+            await _bucketExtension.SetAsync("abcd%c3%a9%201234", jsonDocument);
         }
     }
 }
 ```
 
-Storing a JSON object `{"key1": "value1", "key2": 2, "key3": ["3a", "3b", "3c"]}` identified by `xyz1234` key.
+Storing a JSON object `{"key1": "value1", "key2": 2, "key3": ["3a", "3b", "3c"]}` identified by `abcdé 1234` key.

--- a/source/includes/en/extensions/resources.md
+++ b/source/includes/en/extensions/resources.md
@@ -2,6 +2,8 @@
 
 The **resources** extension allows the storage of documents in the server in an isolated space for each chatbot, similar to the **bucket** extension. The main difference is that these documents can be mapped as **contents** for messages sent to the chatbot destinations, through the resource **key**. This means that the chatbot developer can choose to **store the content of its messages in the server** instead of keeping them on the chatbot code side.
 
+**Note: The resource key should always be URI encoded**
+
 To manage all resources programmatically, use **resources** extension sending a command with the following properties:
 
 | Name     | Description                               |
@@ -24,7 +26,7 @@ client.addMessageReceiver('text/plain', async (message) => {
     await client.sendCommand({  
         id: Lime.Guid(),
         method: Lime.CommandMethod.SET,
-        uri: '/resources/xyz1234',
+        uri: '/resources/abcd%c3%a9%201234',
         type: 'application/vnd.lime.media-link+json',
         resource: {
             title: 'Cat',
@@ -44,7 +46,7 @@ async def message_processor_async(message: Message) -> None:
     result = await client.process_command_async(
         Command(
             CommandMethod.SET,
-            '/resources/xyz1234',
+            '/resources/abcd%c3%a9%201234',
             'application/vnd.lime.media-link+json',
             {
                 'title': 'Cat',
@@ -69,7 +71,7 @@ Authorization: Key {YOUR_TOKEN}
 {  
   "id": "{{$guid}}",
   "method": "set",
-  "uri": "/resources/xyz1234",
+  "uri": "/resources/abcd%c3%a9%201234",
   "type": "application/vnd.lime.media-link+json",
   "resource": {
     "title": "Cat",
@@ -94,7 +96,7 @@ Content-Type: application/json
     "from": "postmaster@msging.net/#az-iris3",
     "to": "contact@msging.net",
     "metadata": {
-        "#command.uri": "lime://contact@msging.net/resources/xyz1234"
+        "#command.uri": "lime://contact@msging.net/resources/abcd%c3%a9%201234"
     }
 }
 ```
@@ -132,13 +134,13 @@ namespace Extensions
                 PreviewUri = new Uri("https://encrypted-tbn3.gstatic.com/images?q=tbn:ANd9GcS8qkelB28RstsNxLi7gbrwCLsBVmobPjb5IrwKJSuqSnGX4IzX")
             };
 
-            await _resourceExtension.SetAsync<MediaLink>("xyz1234", mediaLink);
+            await _resourceExtension.SetAsync<MediaLink>("abcd%c3%a9%201234", mediaLink);
         }
     }
 }
 ```
 
-Storing a `media link` document with `xyz1234` key.
+Storing a `media link` document with `abcdé 1234` key.
 
 ### Add a **text/plain** resource
 
@@ -147,7 +149,7 @@ client.addMessageReceiver('text/plain', async (message) => {
     await client.sendCommand({  
         id: Lime.Guid(),
         method: Lime.CommandMethod.SET,
-        uri: '/resources/help-message',
+        uri: '/resources/abcd%c3%a9%201234',
         type: 'text/plain',
         resource: 'To use our services, please send a text message.'
     });
@@ -159,7 +161,7 @@ async def message_processor_async(message: Message) -> None:
     result = await client.process_command_async(
         Command(
             CommandMethod.SET,
-            '/resources/help-message',
+            '/resources/abcd%c3%a9%201234',
             'text/plain',
             'To use our services, please send a text message.'
         )
@@ -176,7 +178,7 @@ Authorization: Key {YOUR_TOKEN}
 {  
   "id": "{{$guid}}",
   "method": "set",
-  "uri": "/resources/help-message",
+  "uri": "/resources/abcd%c3%a9%201234",
   "type": "text/plain",
   "resource": "To use our services, please send a text message."
 }
@@ -193,7 +195,7 @@ Content-Type: application/json
     "from": "postmaster@msging.net/#az-iris6",
     "to": "contact@msging.net",
     "metadata": {
-        "#command.uri": "lime://contact@msging.net/resources/help-message"
+        "#command.uri": "lime://contact@msging.net/resources/abcd%c3%a9%201234"
     }
 }
 ```
@@ -226,13 +228,13 @@ namespace Extensions
                 Text = "To use our services, please send a text message."
             };
 
-            await _resourceExtension.SetAsync<PlainText>("help-message", plainText);   
+            await _resourceExtension.SetAsync<PlainText>("abcd%c3%a9%201234", plainText);   
         }
     }
 }
 ```
 
-Storing a `text plain` document with `help-message` key.
+Storing a `text plain` document with `abcdé 1234` key.
 
 ### Delete a specific resource
 
@@ -241,7 +243,7 @@ client.addMessageReceiver('text/plain', async (message) => {
     await client.sendCommand({  
         id: Lime.Guid(),
         method: Lime.CommandMethod.DELETE,
-        uri: '/resources/xyz1234'
+        uri: '/resources/abcd%c3%a9%201234'
     });
 });
 ```
@@ -251,7 +253,7 @@ async def message_processor_async(message: Message) -> None:
     result = await client.process_command_async(
         Command(
             CommandMethod.DELETE,
-            '/resources/xyz1234'
+            '/resources/abcd%c3%a9%201234'
         )
     )
 
@@ -266,7 +268,7 @@ Authorization: Key {YOUR_TOKEN}
 {  
   "id": "{{$guid}}",
   "method": "delete",
-  "uri": "/resources/xyz1234"
+  "uri": "/resources/abcd%c3%a9%201234"
 }
 ```
 
@@ -281,7 +283,7 @@ Content-Type: application/json
     "from": "postmaster@msging.net/#az-iris1",
     "to": "docstest@msging.net",
     "metadata": {
-        "#command.uri": "lime://docstest@msging.net/resources/xyz1234"
+        "#command.uri": "lime://docstest@msging.net/resources/abcd%c3%a9%201234"
     }
 }
 ```
@@ -306,7 +308,7 @@ namespace Extensions
 
         public async Task ReceiveAsync(Message envelope, CancellationToken cancellationToken)
         {
-            await _resourceExtension.DeleteAsync("xyz1234", cancellationToken);
+            await _resourceExtension.DeleteAsync("abcd%c3%a9%201234", cancellationToken);
         }
     }
 }
@@ -321,7 +323,7 @@ client.addMessageReceiver('text/plain', async (message) => {
     var resource = await client.sendCommand({  
         id: Lime.Guid(),
         method: Lime.CommandMethod.GET,
-        uri: '/resources/xyz1234'
+        uri: '/resources/abcd%c3%a9%201234'
     });
     console.log(resource);
 });
@@ -332,7 +334,7 @@ async def message_processor_async(message: Message) -> None:
     result = await client.process_command_async(
         Command(
             CommandMethod.GET,
-            '/resources/xyz1234'
+            '/resources/abcd%c3%a9%201234'
         )
     )
 
@@ -347,7 +349,7 @@ Authorization: Key {YOUR_TOKEN}
 {  
   "id": "{{$guid}}",
   "method": "get",
-  "uri": "/resources/xyz1234"
+  "uri": "/resources/abcd%c3%a9%201234"
 }
 ```
 
@@ -372,7 +374,7 @@ Content-Type: application/json
     "from": "postmaster@msging.net/#az-iris6",
     "to": "docstest@msging.net",
     "metadata": {
-        "#command.uri": "lime://docstest@msging.net/resources/xyz1234"
+        "#command.uri": "lime://docstest@msging.net/resources/abcd%c3%a9%201234"
     }
 }
 ```
@@ -398,7 +400,7 @@ namespace Extensions
 
         public async Task ReceiveAsync(Message envelope, CancellationToken cancellationToken)
         {
-            var resource = await _resourceExtension.GetAsync<MediaLink>("xyz1234", cancellationToken);
+            var resource = await _resourceExtension.GetAsync<MediaLink>("abcd%c3%a9%201234", cancellationToken);
         }
     }
 }
@@ -454,7 +456,7 @@ Content-Type: application/json
         "itemType": "text/plain",
         "items": [
             "help-message",
-            "xyz1234"
+            "abcdé 1234"
         ]
     },
     "method": "get",
@@ -510,7 +512,7 @@ client.addMessageReceiver('text/plain', async (message) => {
     await client.sendCommand({  
         id: Lime.Guid(),
         method: Lime.CommandMethod.SET,
-        uri: '/resources/welcome-message',
+        uri: '/resources/abcd%c3%a9%201234',
         type: 'text/plain',
         resource: 'Welcome to our service, ${contact.name}!'
     });
@@ -522,7 +524,7 @@ async def message_processor_async(message: Message) -> None:
     result = await client.process_command_async(
         Command(
             CommandMethod.SET,
-            '/resources/welcome-message',
+            '/resources/abcd%c3%a9%201234',
             'text/plain',
             'Welcome to our service, ${contact.name}!'
         )
@@ -539,7 +541,7 @@ Authorization: Key {YOUR_TOKEN}
 {  
   "id": "{{$guid}}",
   "method": "set",
-  "uri": "/resources/welcome-message",
+  "uri": "/resources/abcd%c3%a9%201234",
   "type": "text/plain",
   "resource": "Welcome to our service, ${contact.name}!"
 }
@@ -556,7 +558,7 @@ Content-Type: application/json
     "from": "postmaster@msging.net/#az-iris2",
     "to": "contact@msging.net",
     "metadata": {
-        "#command.uri": "lime://contact@msging.net/resources/welcome-message"
+        "#command.uri": "lime://contact@msging.net/resources/abcd%c3%a9%201234"
     }
 }
 ```
@@ -589,12 +591,12 @@ namespace Extensions
                 Text = "Welcome to our service, ${contact.name}!"
             };
 
-            await _resourceExtension.SetAsync<PlainText>("welcome-message", plainText);            
+            await _resourceExtension.SetAsync<PlainText>("abcd%c3%a9%201234", plainText);            
         }
     }
 }
 ```
 
-Storing a `text plain` document with `welcome-message` key using replacement variables.
+Storing a `text plain` document with `abcdé 1234` key using replacement variables.
 
 It is possible to use contact replacement variables in the created resources, just as in this example. For more information, please check the documentation of the [**Contacts** extension](#contacts).


### PR DESCRIPTION
Currently, our LimeUri class expects the received URI to be URI Encoded.

This PR intends to make that explicit in our Docs.